### PR TITLE
Add ability to remove links

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,12 @@
         "command": "dochub.collapseAll",
         "title": "Collapse all",
         "icon": "$(collapse-all)"
+      },
+      {
+        "command": "dochub.removeDocs",
+        "title": "Remove Documentation",
+        "category": "DocHub",
+        "icon": "$(trash)"
       }
     ],
     "views": {
@@ -112,6 +118,10 @@
         {
           "command": "dochub.collapseAll",
           "when": "false"
+        },
+        {
+          "command": "dochub.removeDocs",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -141,6 +151,11 @@
           "command": "dochub.openInBrowser",
           "when": "view == dochub && viewItem == dochub.link",
           "group": "inline@1"
+        },
+        {
+          "command": "dochub.removeDocs",
+          "when": "view == dochub && viewItem == dochub.link",
+          "group": "inline@2"
         }
       ]
     }

--- a/src/constants/Command.ts
+++ b/src/constants/Command.ts
@@ -10,4 +10,6 @@ export const COMMAND = {
   collapseAll: `${EXTENSION_NAME}.collapseAll`,
   // Output
   showOutputChannel: `${EXTENSION_NAME}.showOutputChannel`,
+  // Remove
+  removeDocs: `${EXTENSION_NAME}.removeDocs`,
 };

--- a/src/services/CommandsService.ts
+++ b/src/services/CommandsService.ts
@@ -27,6 +27,9 @@ export class CommandsService {
     subscriptions.push(
       commands.registerCommand(COMMAND.collapseAll, PanelService.collapseAll)
     );
+    subscriptions.push(
+      commands.registerCommand(COMMAND.removeDocs, CommandsService.removeDocs)
+    );
   }
 
   private static async addDocs() {
@@ -92,6 +95,28 @@ export class CommandsService {
     const docsUri = Uri.joinPath(workspaceFolder.uri, General.docsFile);
     if (await fileExists(docsUri)) {
       await window.showTextDocument(docsUri);
+    }
+  }
+
+  private static async removeDocs(item: string | DocHubTreeItem | undefined) {
+    let url = item;
+    if (typeof item === "object") {
+      url = item.url;
+    }
+
+    if (!url) {
+      return;
+    }
+
+    const confirm = await window.showWarningMessage(
+      `Are you sure you want to remove the documentation link for "${url}"?`,
+      { modal: true },
+      "Yes"
+    );
+
+    if (confirm === "Yes") {
+      await DocsService.removeFromDocs(url);
+      PanelService.update();
     }
   }
 }

--- a/src/services/CommandsService.ts
+++ b/src/services/CommandsService.ts
@@ -99,8 +99,10 @@ export class CommandsService {
   }
 
   private static async removeDocs(item: string | DocHubTreeItem | undefined) {
+    let title = item;
     let url = item;
     if (typeof item === "object") {
+      title = item.label;
       url = item.url;
     }
 
@@ -109,13 +111,13 @@ export class CommandsService {
     }
 
     const confirm = await window.showWarningMessage(
-      `Are you sure you want to remove the documentation link for "${url}"?`,
+      `Are you sure you want to remove the documentation link for "${title}"?`,
       { modal: true },
       "Yes"
     );
 
     if (confirm === "Yes") {
-      await DocsService.removeFromDocs(url);
+      await DocsService.removeFromDocs(url as string);
       PanelService.update();
     }
   }

--- a/src/services/DocsService.ts
+++ b/src/services/DocsService.ts
@@ -44,6 +44,17 @@ export class DocsService {
     return [];
   }
 
+  public static async removeFromDocs(url: string) {
+    const docsFile = await DocsService.getDocs();
+    if (!docsFile) {
+      return;
+    }
+
+    const updatedDocs = docsFile.filter((doc) => doc.url !== url);
+
+    await DocsService.updateDocsFile(updatedDocs);
+  }
+
   private static async updateDocsFile(docs: DocLink[]) {
     const workspaceFolder = Extension.getInstance().workspaceFolder;
     if (!workspaceFolder) {


### PR DESCRIPTION
Fixes #1

Add functionality to remove documentation links.

* **Commands**: Add `removeDocs` command to `COMMAND` object in `src/constants/Command.ts`. Register `removeDocs` command in `src/services/CommandsService.ts` and add `removeDocs` method to handle link removal.
* **DocsService**: Add `removeFromDocs` method in `src/services/DocsService.ts` to remove links.
* **PanelService**: Add context menu item for removing links in `src/services/PanelService.ts`.
* **package.json**: Add `dochub.removeDocs` command to `contributes.commands` and `contributes.menus`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/estruyf/vscode-dochub/pull/6?shareId=bea76add-df8d-427f-a7a9-2bf6eed6d575).