### PR TITLE
Add framework detection using JSON file

### DIFF
--- a/frameworks.json
+++ b/frameworks.json
@@ -1,0 +1,22 @@
+{
+  "frameworks": [
+    {
+      "name": "React",
+      "files": ["package.json"],
+      "contents": ["react"],
+      "links": ["https://react.dev/"]
+    },
+    {
+      "name": "Vue",
+      "files": ["package.json"],
+      "contents": ["vue"],
+      "links": ["https://vuejs.org/guide/introduction.html"]
+    },
+    {
+      "name": "Angular",
+      "files": ["package.json"],
+      "contents": ["@angular/core"],
+      "links": ["https://angular.io/start"]
+    }
+  ]
+}

--- a/frameworks.json
+++ b/frameworks.json
@@ -17,6 +17,12 @@
       "files": ["package.json"],
       "contents": ["@angular/core"],
       "links": ["https://angular.io/start"]
+    },
+    {
+      "name": "Slidev",
+      "files": ["package.json"],
+      "contents": ["@slidev/cli"],
+      "links": ["https://sli.dev/"]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -183,5 +183,9 @@
   },
   "dependencies": {
     "jsonc-parser": "^3.3.1"
-  }
+  },
+  "files": [
+    "dist",
+    "frameworks.json"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -144,12 +144,12 @@
       "view/item/context": [
         {
           "command": "dochub.openDocs",
-          "when": "view == dochub && viewItem == dochub.link",
+          "when": "view == dochub && viewItem =~ /dochub.link/",
           "group": "inline@0"
         },
         {
           "command": "dochub.openInBrowser",
-          "when": "view == dochub && viewItem == dochub.link",
+          "when": "view == dochub && viewItem =~ /dochub.link/",
           "group": "inline@1"
         },
         {

--- a/src/models/FrameworkInfo.ts
+++ b/src/models/FrameworkInfo.ts
@@ -1,0 +1,10 @@
+export interface FrameworkInfo {
+  frameworks: Framework[];
+}
+
+export interface Framework {
+  name: string;
+  files: string[];
+  contents: string[];
+  links: string[];
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,2 +1,3 @@
 export * from "./DocLink";
+export * from "./FrameworkInfo";
 export * from "./Subscription";

--- a/src/services/DocHubTreeviewProvider.ts
+++ b/src/services/DocHubTreeviewProvider.ts
@@ -44,7 +44,8 @@ export class DocHubTreeItem extends TreeItem {
     command?: string,
     public url?: string,
     icon?: Uri | string,
-    private children?: DocHubTreeItem[]
+    private children?: DocHubTreeItem[],
+    contextValue?: string
   ) {
     super(
       label,
@@ -74,6 +75,10 @@ export class DocHubTreeItem extends TreeItem {
       : undefined;
 
     this.contextValue = url ? "dochub.link" : "dochub.folder";
+
+    if (contextValue) {
+      this.contextValue += ` ${contextValue}`;
+    }
 
     this.children = children;
   }

--- a/src/services/Extension.ts
+++ b/src/services/Extension.ts
@@ -2,6 +2,7 @@ import {
   ExtensionContext,
   ExtensionMode,
   SecretStorage,
+  Uri,
   workspace,
 } from "vscode";
 import { Config } from "../constants";
@@ -77,6 +78,13 @@ export class Extension {
    */
   public get extensionPath(): string {
     return this.ctx.extensionPath;
+  }
+
+  /**
+   * Get the extension's URI
+   */
+  public get extensionUri(): Uri {
+    return this.ctx.extensionUri;
   }
 
   /**

--- a/src/services/FrameworkDiscovery.ts
+++ b/src/services/FrameworkDiscovery.ts
@@ -1,20 +1,13 @@
 import { Uri, workspace } from "vscode";
 
 export class FrameworkDiscovery {
-  private static frameworks: Array<
-    keyof typeof FrameworkDiscovery.frameworkDocs
-  > = ["react", "vue", "angular", "@slidev/cli"];
-  private static frameworkDocs: { [key: string]: string } = {
-    react: "https://react.dev/",
-    vue: "https://vuejs.org/guide/introduction.html",
-    angular: "https://angular.io/start",
-    "@slidev/cli": "https://sli.dev/guide/",
-  };
+  private static frameworks: Array<string> = [];
+  private static frameworkDocs: { [key: string]: string } = {};
 
   public static async discover() {
     const frameworks = await FrameworkDiscovery.getFrameworks();
     if (frameworks) {
-      // Retrun all the frameworks with their documentation links
+      // Return all the frameworks with their documentation links
       return frameworks.map((framework) => {
         return {
           name: framework,
@@ -74,4 +67,33 @@ export class FrameworkDiscovery {
     );
     return frameworks;
   }
+
+  public static async loadFrameworks() {
+    const workspaceFolders = workspace.workspaceFolders;
+    if (!workspaceFolders) {
+      return;
+    }
+
+    for (const folder of workspaceFolders) {
+      const frameworksJsonUri = Uri.joinPath(folder.uri, "frameworks.json");
+      const frameworksJson = await workspace.fs.readFile(frameworksJsonUri);
+      if (frameworksJson) {
+        const frameworksTxt = Buffer.from(frameworksJson).toString("utf-8");
+        const frameworksData = JSON.parse(frameworksTxt);
+        FrameworkDiscovery.frameworks = frameworksData.frameworks.map(
+          (framework: any) => framework.contents[0]
+        );
+        FrameworkDiscovery.frameworkDocs = frameworksData.frameworks.reduce(
+          (acc: any, framework: any) => {
+            acc[framework.contents[0]] = framework.links[0];
+            return acc;
+          },
+          {}
+        );
+      }
+    }
+  }
 }
+
+// Load frameworks from frameworks.json
+FrameworkDiscovery.loadFrameworks();

--- a/src/services/FrameworkDiscovery.ts
+++ b/src/services/FrameworkDiscovery.ts
@@ -1,14 +1,24 @@
+import { Framework } from "./../models/FrameworkInfo";
 import { Uri, workspace } from "vscode";
+import { Extension } from "./Extension";
 
 export class FrameworkDiscovery {
-  private static frameworks: Array<string> = [];
+  private static frameworks: Framework[] = [];
   private static frameworkDocs: { [key: string]: string } = {};
+  private static frameworkFiles: { [key: string]: any } = {};
 
   public static async discover() {
+    await FrameworkDiscovery.loadFrameworks();
+
+    let frameworkLinks: {
+      name: string;
+      link: string;
+    }[] = [];
+
     const frameworks = await FrameworkDiscovery.getFrameworks();
     if (frameworks) {
       // Return all the frameworks with their documentation links
-      return frameworks.map((framework) => {
+      frameworkLinks = frameworks.map((framework) => {
         return {
           name: framework,
           link:
@@ -18,13 +28,33 @@ export class FrameworkDiscovery {
         };
       });
     }
-    return null;
+
+    FrameworkDiscovery.frameworkFiles = {};
+    return frameworkLinks;
   }
 
   private static async getFrameworks() {
+    const frameworks: string[] = [];
+
+    for (const framework of FrameworkDiscovery.frameworks) {
+      const files = framework.files;
+      for (const file of files) {
+        if (file === "package.json") {
+          const discovered = await FrameworkDiscovery.processPackageJson(
+            framework
+          );
+          frameworks?.push(...discovered);
+        }
+      }
+    }
+
+    return frameworks.flat().filter((framework) => framework !== null);
+  }
+
+  private static async processPackageJson(framework: Framework) {
     const packageJson = await FrameworkDiscovery.getPackageJson();
     if (!packageJson) {
-      return null;
+      return [];
     }
 
     const packageJsonDependencies = [
@@ -32,19 +62,24 @@ export class FrameworkDiscovery {
       ...Object.keys(packageJson.devDependencies || {}),
     ];
     if (!packageJsonDependencies) {
-      return null;
+      return [];
     }
 
     const frameworks = FrameworkDiscovery.getFrameworkFromDependencies(
-      packageJsonDependencies
+      packageJsonDependencies,
+      framework
     );
     return frameworks;
   }
 
   private static async getPackageJson() {
+    if (FrameworkDiscovery.frameworkFiles["package.json"]) {
+      return FrameworkDiscovery.frameworkFiles["package.json"];
+    }
+
     const workspaceFolders = workspace.workspaceFolders;
     if (!workspaceFolders) {
-      return null;
+      return;
     }
 
     for (const folder of workspaceFolders) {
@@ -52,48 +87,51 @@ export class FrameworkDiscovery {
       const packageJson = await workspace.fs.readFile(packageJsonUri);
       if (packageJson) {
         const packageTxt = Buffer.from(packageJson).toString("utf-8");
-        return JSON.parse(packageTxt);
+        FrameworkDiscovery.frameworkFiles["package.json"] =
+          JSON.parse(packageTxt);
+        return FrameworkDiscovery.frameworkFiles["package.json"];
       }
     }
 
-    return null;
+    return;
   }
 
   private static getFrameworkFromDependencies(
-    dependencies: string[]
+    dependencies: string[],
+    framework: Framework
   ): string[] {
-    const frameworks = dependencies.filter((dependency) =>
-      FrameworkDiscovery.frameworks.includes(dependency)
-    );
+    const frameworks = dependencies.filter((dependency) => {
+      return framework.contents.some((content) => {
+        return dependency.includes(content);
+      });
+    });
     return frameworks;
   }
 
-  public static async loadFrameworks() {
-    const workspaceFolders = workspace.workspaceFolders;
-    if (!workspaceFolders) {
+  private static async loadFrameworks() {
+    if (FrameworkDiscovery.frameworks.length > 0) {
       return;
     }
 
-    for (const folder of workspaceFolders) {
-      const frameworksJsonUri = Uri.joinPath(folder.uri, "frameworks.json");
-      const frameworksJson = await workspace.fs.readFile(frameworksJsonUri);
-      if (frameworksJson) {
-        const frameworksTxt = Buffer.from(frameworksJson).toString("utf-8");
-        const frameworksData = JSON.parse(frameworksTxt);
-        FrameworkDiscovery.frameworks = frameworksData.frameworks.map(
-          (framework: any) => framework.contents[0]
-        );
-        FrameworkDiscovery.frameworkDocs = frameworksData.frameworks.reduce(
-          (acc: any, framework: any) => {
-            acc[framework.contents[0]] = framework.links[0];
-            return acc;
-          },
-          {}
-        );
-      }
+    const ext = Extension.getInstance();
+    if (!ext) {
+      return;
+    }
+
+    const extensionUri = ext.extensionUri;
+    const frameworksJsonUri = Uri.joinPath(extensionUri, "frameworks.json");
+    const frameworksJson = await workspace.fs.readFile(frameworksJsonUri);
+    if (frameworksJson) {
+      const frameworksTxt = Buffer.from(frameworksJson).toString("utf-8");
+      const frameworksData = JSON.parse(frameworksTxt);
+      FrameworkDiscovery.frameworks = frameworksData.frameworks;
+      FrameworkDiscovery.frameworkDocs = frameworksData.frameworks.reduce(
+        (acc: any, framework: any) => {
+          acc[framework.contents[0]] = framework.links[0];
+          return acc;
+        },
+        {}
+      );
     }
   }
 }
-
-// Load frameworks from frameworks.json
-FrameworkDiscovery.loadFrameworks();

--- a/src/services/PanelService.ts
+++ b/src/services/PanelService.ts
@@ -74,14 +74,16 @@ export class PanelService {
           "Frameworks",
           undefined,
           undefined,
-          undefined,
+          "tools",
           frameworkLinks.map(
             (framework) =>
               new DocHubTreeItem(
                 framework.name,
                 COMMAND.openDocs,
                 framework.link,
-                undefined
+                undefined,
+                undefined,
+                "dochub.framework"
               )
           )
         )


### PR DESCRIPTION
Fixes #2

Add a JSON file for framework definitions and update framework detection system.

* Add `frameworks.json` to define frameworks, their files, contents, and links.
* Modify `src/services/FrameworkDiscovery.ts` to read framework definitions from `frameworks.json` instead of hardcoded values.
* Update `package.json` to include `frameworks.json` in the extension's files.
* Add popular frameworks like React, Vue, and Angular to `frameworks.json`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/estruyf/vscode-dochub/pull/8?shareId=c5a4ba68-b806-4cc9-85e0-30be39941de4).