### PR TITLE
Enhancement: Ask for the category

### DIFF
--- a/src/services/CommandsService.ts
+++ b/src/services/CommandsService.ts
@@ -47,7 +47,22 @@ export class CommandsService {
       value: title,
     });
 
-    await DocsService.addToDocs(url, title);
+    const existingCategories = await DocsService.getCategories();
+    const category = await window.showQuickPick(
+      [...existingCategories, "Add new category..."],
+      {
+        placeHolder: "Select a category or add a new one",
+      }
+    );
+
+    let newCategory: string | undefined;
+    if (category === "Add new category...") {
+      newCategory = await window.showInputBox({
+        prompt: "Enter the new category",
+      });
+    }
+
+    await DocsService.addToDocs(url, title, newCategory || category);
     PanelService.update();
   }
 

--- a/src/services/DocsService.ts
+++ b/src/services/DocsService.ts
@@ -69,4 +69,17 @@ export class DocsService {
       );
     }
   }
+
+  public static async getCategories(): Promise<string[]> {
+    const docs = await DocsService.getDocs();
+    if (!docs) {
+      return [];
+    }
+
+    const categories = docs
+      .map((doc) => doc.category)
+      .filter((category) => category !== undefined) as string[];
+
+    return Array.from(new Set(categories));
+  }
 }


### PR DESCRIPTION
Fixes #11

Add category selection to documentation link creation process.

* Modify `src/services/CommandsService.ts` to prompt the user for a category after asking for the URL and title.
* Allow the user to select an existing category or add a new category.
* Pass the selected or new category to the `DocsService.addToDocs` method.
* Add a new method `getCategories` in `src/services/DocsService.ts` to retrieve existing categories from the documentation links.
* Ensure the category is included in the new documentation link object.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/estruyf/vscode-dochub/pull/12?shareId=d59c29a4-99ab-48fb-8694-e2dfd66da212).